### PR TITLE
Update for argonaut release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "purescript-typelevel": "^5.0.0",
     "purescript-typelevel-prelude": "^5.0.0",
     "purescript-generics-rep": "6.1.1",
-    "purescript-argonaut": "6.0.0",
+    "purescript-argonaut": "7.0.0",
     "purescript-quickcheck": "^6.1.0"
   },
   "devDependencies": {

--- a/src/Refined.purs
+++ b/src/Refined.purs
@@ -18,7 +18,7 @@ import Prelude (class Eq, class Show, bind, show, (<$>), (<<<))
 import Data.Typelevel.Undefined (undefined)
 import Data.Bifunctor (lmap)
 import Data.Argonaut (class EncodeJson)
-import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, JsonDecodeError(..))
 import Data.Either (Either, isRight)
 import Data.Generic.Rep (class Generic)
 import Data.Ord (class Ord)
@@ -44,7 +44,7 @@ instance decodeJsonRefined
   => DecodeJson (Refined p x) where
   decodeJson a = do
      val <- decodeJson a
-     (refineStr val :: Either String (Refined p x))
+     (refineJson val :: Either JsonDecodeError (Refined p x))
 
 -- | for encoding we just want to strip away the outside layer and use whatever
 -- | is inside
@@ -63,12 +63,12 @@ instance arbitraryRefined
 
 
 -- used by decode json for it's errors
-refineStr 
+refineJson 
   :: forall p x. (Predicate p x)
   => (Show x) 
   => x 
-  -> Either String (Refined p x)
-refineStr x = lmap show (refine x)
+  -> Either JsonDecodeError (Refined p x)
+refineJson x = lmap (TypeMismatch <<< show) (refine x)
 
 -- the regular way in which one would turn a value into a Refined value
 refine 


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates this library for compatibility.

If everything looks good, would you mind making a new release with the updated code so it's compatible with the upcoming package set? That'll ensure this package stays in the set.

Sorry for the hassle! Thanks!